### PR TITLE
Fixed HA 2024.2.2 incompability in async_setup_entry

### DIFF
--- a/custom_components/awattar_energy_cost/__init__.py
+++ b/custom_components/awattar_energy_cost/__init__.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # add market area to shell
     shell.add_entry(entry)
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Replace call to obsolete method async_setup_platforms by async_forward_entry_setups.

Resolves Issue No. #8